### PR TITLE
Translate forms on process

### DIFF
--- a/gf_pll.php
+++ b/gf_pll.php
@@ -30,6 +30,7 @@ class GF_PLL_Initialize {
 
 add_action('gform_loaded', array('GF_PLL_Initialize', 'register_strings'));
 add_filter('gform_pre_render', array('GF_PLL_Initialize', 'translate_strings'));
+add_filter('gform_pre_process', array('GF_PLL_Initialize', 'translate_strings'));
 
 endif;
 


### PR DESCRIPTION
I noticed forms where not translates when displaying confirmation messages.
Hooking in the `gform_pre_process` filter works