### PR TITLE
Add sublabels to registered strings

### DIFF
--- a/class_GF_PLL.php
+++ b/class_GF_PLL.php
@@ -24,6 +24,7 @@ class GF_PLL {
       'errorMessage',
       'placeholder',
       'label',
+      'customLabel',
       'value',
       'subject'
     );


### PR DESCRIPTION
Class didn't register custom sublabels that are created inside Gravity Forms edit screens.